### PR TITLE
fix: connect to remote peer and show status

### DIFF
--- a/packages/nextjs/src/lib/libp2p.ts
+++ b/packages/nextjs/src/lib/libp2p.ts
@@ -37,7 +37,7 @@ export async function startLibp2p() {
 
   // libp2p is the networking layer that underpins Helia
   const libp2p = await createLibp2p({
-    connectionManager: { autoDial: false },
+    // connectionManager: { autoDial: false },
     dht: kadDHT(),
     datastore,
     transports: [webTransport(), webSockets()],
@@ -61,7 +61,7 @@ export async function startLibp2p() {
         ],
       }),
     ],
-    peerRouters: [delegatedPeerRouting(client)],
+    // peerRouters: [delegatedPeerRouting(client)],
   })
 
   console.log(`this nodes peerID: ${libp2p.peerId.toString()}`)
@@ -115,7 +115,9 @@ export const connectToMultiaddrs =
       multiaddr = addPeerIdToWebTransportMultiAddr(multiaddr, peerId)
       console.log(`dialling: ${multiaddr.toString()}`)
       try {
-        conns.push(await libp2p.dial(multiaddr))
+        const conn = await libp2p.dial(multiaddr)
+        conns.push(conn)
+        console.info('connected to', conn.remotePeer, 'on', conn.remoteAddr)
       } catch (e) {
         errs.push(e)
         console.error(e)

--- a/packages/nextjs/src/pages/index.tsx
+++ b/packages/nextjs/src/pages/index.tsx
@@ -71,6 +71,12 @@ export default function Home() {
         if (multiaddrs) {
           const connections = await connectToMultiaddrs(libp2p)(multiaddrs, peerID)
           console.log('connections: ', connections)
+
+          if (connections.find(conn => {
+            return conn.remotePeer.toString() === peerID
+          })) {
+            setIsConnected(true)
+          }
         }
       } catch (e) {
         console.error(e)


### PR DESCRIPTION
- Removes config that turns off autodial
- Removes config that uses delegated peer routing
- After connect succeeds, log the remote peer id and connected multiaddr to the console
- After connect succeeds, check we have connected to the correct peer and set the "is connected" value